### PR TITLE
Let's not assume the directory is non-existent

### DIFF
--- a/bin/install_awscli.sh
+++ b/bin/install_awscli.sh
@@ -6,7 +6,7 @@ chmod u+x $INSTALL_DIR/bin/aws
 
 export PATH=~/vendor/awscli/bin:$PATH
 
-mkdir ~/.aws
+mkdir -p ~/.aws
 
 cat >> ~/.aws/credentials << EOF
 [default]

--- a/bin/install_awscli.sh
+++ b/bin/install_awscli.sh
@@ -8,13 +8,13 @@ export PATH=~/vendor/awscli/bin:$PATH
 
 mkdir -p ~/.aws
 
-cat >> ~/.aws/credentials << EOF
+cat > ~/.aws/credentials << EOF
 [default]
 aws_access_key_id = $AWS_KEY
 aws_secret_access_key = $AWS_SECRET_KEY
 EOF
 
-cat >> ~/.aws/config << EOF
+cat > ~/.aws/config << EOF
 [default]
 region = $AWS_REGION
 EOF


### PR DESCRIPTION
`/exec rails c` breaks in GCP kubeshell due to this shell script trying to make a directory that already exists.

This fixes that behaviour