### PR TITLE
Moves the chmod commands into the compile script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,11 @@ mkdir -p $BUILD_DIR/.profile.d
 cp "$BUILDPACK_DIR/bin/install_awscli.sh" $BUILD_DIR/.profile.d/
 chmod +x $BUILD_DIR/.profile.d/install_awscli.sh
 
+INSTALL_DIR="/app/vendor/awscli"
+chmod +x /app/vendor/awscli-bundle/install
+/app/vendor/awscli-bundle/install -i $INSTALL_DIR
+chmod u+x $INSTALL_DIR/bin/aws
+
 #cleaning up...
 rm -rf /tmp/awscli*
 

--- a/bin/compile
+++ b/bin/compile
@@ -30,8 +30,8 @@ cp "$BUILDPACK_DIR/bin/install_awscli.sh" $BUILD_DIR/.profile.d/
 chmod +x $BUILD_DIR/.profile.d/install_awscli.sh
 
 INSTALL_DIR="/app/vendor/awscli"
-chmod +x /app/vendor/awscli-bundle/install
-/app/vendor/awscli-bundle/install -i $INSTALL_DIR
+chmod +x "$BUILD_DIR/vendor/awscli-bundle/install"
+"$BUILD_DIR/vendor/awscli-bundle/install" -i $INSTALL_DIR
 chmod u+x $INSTALL_DIR/bin/aws
 
 #cleaning up...

--- a/bin/install_awscli.sh
+++ b/bin/install_awscli.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-INSTALL_DIR="/app/vendor/awscli"
-chmod +x /app/vendor/awscli-bundle/install
-/app/vendor/awscli-bundle/install -i $INSTALL_DIR
-chmod u+x $INSTALL_DIR/bin/aws
-
 export PATH=~/vendor/awscli/bin:$PATH
 
 mkdir -p ~/.aws


### PR DESCRIPTION
The way this buildpack works is that the `compile` script runs at build time, and then the `install_awscli.sh` script runs at runtime. In order to support the future deployment of security contexts on our kubernetes workloads, we moved the `chmod` commands out of the `install_awscli` script and into the `compile` script so that the resulting container does not need `chmod` permissions and we can drop those from the container.

🎩 with the only app (shopify/shopify-app-store) that uses this buildpack