### PR TITLE
Revert breaking commits.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,11 +29,6 @@ mkdir -p $BUILD_DIR/.profile.d
 cp "$BUILDPACK_DIR/bin/install_awscli.sh" $BUILD_DIR/.profile.d/
 chmod +x $BUILD_DIR/.profile.d/install_awscli.sh
 
-INSTALL_DIR="/app/vendor/awscli"
-chmod +x "$BUILD_DIR/vendor/awscli-bundle/install"
-"$BUILD_DIR/vendor/awscli-bundle/install" -i $INSTALL_DIR
-chmod u+x $INSTALL_DIR/bin/aws
-
 #cleaning up...
 rm -rf /tmp/awscli*
 

--- a/bin/install_awscli.sh
+++ b/bin/install_awscli.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+INSTALL_DIR="/app/vendor/awscli"
+chmod +x /app/vendor/awscli-bundle/install
+/app/vendor/awscli-bundle/install -i $INSTALL_DIR
+chmod u+x $INSTALL_DIR/bin/aws
+
 export PATH=~/vendor/awscli/bin:$PATH
 
 mkdir -p ~/.aws


### PR DESCRIPTION
After the most recent changes; Heroku builds that call the `aws` command fail with:

```
/bin/sh: 1: aws: not found
```

This PR reverts the recent commits until the underlying cause can be identified.